### PR TITLE
Add base path support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    krakend-openapi-importer (1.1.1)
+    krakend-openapi-importer (1.2.0)
       thor (~> 1.2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ format: "json" # can be 'json' or 'yaml', optional, defaults to 'json'
 pretty: false # make JSON pretty, optional, defaults to false
 output: "output.json" # output file name, optional, defaults to 'output.json'
 default_roles: ["guest"] # fall back roles for auth validator plugin when operation 'x-jwt-roles` are not specified, optional
+base_path: '/api/v1' # optional, defaults to ''
 defaults:
   base:
     name: Example application

--- a/lib/importer/version.rb
+++ b/lib/importer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module KrakendOpenAPI
-  VERSION = '1.1.1'
+  VERSION = '1.2.0'
 end

--- a/lib/transformers/oa3_transformer.rb
+++ b/lib/transformers/oa3_transformer.rb
@@ -61,14 +61,17 @@ module KrakendOpenAPI
     end
 
     def krakend_endpoint(path, method)
+      base_path = @importer_config['base_path'] || ''
+      endpoint_path = "#{base_path}#{path}"
+
       {
-        endpoint: path,
+        endpoint: endpoint_path,
         method: method.upcase,
         output_encoding: @importer_config['defaults']&.dig('endpoint', 'output_encoding'),
         input_headers: @importer_config['defaults']&.dig('endpoint', 'input_headers'),
         input_query_strings: @importer_config['defaults']&.dig('endpoint', 'input_query_strings'),
         backend: [{
-          url_pattern: path,
+          url_pattern: endpoint_path,
           encoding: @importer_config['defaults']&.dig('backend', 0, 'encoding'),
           host: @importer_config['defaults']&.dig('backend', 0, 'host')
         }.compact]

--- a/test/fixtures/importer.yaml
+++ b/test/fixtures/importer.yaml
@@ -4,6 +4,7 @@ default_roles:
   - 'guest'
 pretty: false
 output: 'output.json'
+base_path: '/api/v1'
 defaults:
   base:
     name: Test Name

--- a/test/fixtures/krakend-endpoints-output.json
+++ b/test/fixtures/krakend-endpoints-output.json
@@ -4,7 +4,7 @@
   "name": "Test Name",
   "endpoints": [
     {
-      "endpoint": "/pet",
+      "endpoint": "/api/v1/pet",
       "method": "POST",
       "output_encoding": "no-op",
       "input_headers": [
@@ -15,7 +15,7 @@
       ],
       "backend": [
         {
-          "url_pattern": "/pet",
+          "url_pattern": "/api/v1/pet",
           "encoding": "no-op",
           "host": ["https://example.org"]
         }
@@ -40,7 +40,7 @@
       }
     },
     {
-      "endpoint": "/pet/{petId}",
+      "endpoint": "/api/v1/pet/{petId}",
       "method": "GET",
       "output_encoding": "no-op",
       "input_headers": [
@@ -51,7 +51,7 @@
       ],
       "backend": [
         {
-          "url_pattern": "/pet/{petId}",
+          "url_pattern": "/api/v1/pet/{petId}",
           "encoding": "no-op",
           "host": ["https://example.org"]
         }
@@ -72,7 +72,7 @@
       }
     },
     {
-      "endpoint": "/pet/{petId}",
+      "endpoint": "/api/v1/pet/{petId}",
       "method": "PATCH",
       "output_encoding": "no-op",
       "input_headers": [
@@ -83,7 +83,7 @@
       ],
       "backend": [
         {
-          "url_pattern": "/pet/{petId}",
+          "url_pattern": "/api/v1/pet/{petId}",
           "encoding": "no-op",
           "host": ["https://example.org"]
         }
@@ -107,7 +107,7 @@
       }
     },
     {
-      "endpoint": "/pet/{petId}",
+      "endpoint": "/api/v1/pet/{petId}",
       "method": "DELETE",
       "output_encoding": "no-op",
       "input_headers": [
@@ -118,7 +118,7 @@
       ],
       "backend": [
         {
-          "url_pattern": "/pet/{petId}",
+          "url_pattern": "/api/v1/pet/{petId}",
           "encoding": "no-op",
           "host": ["https://example.org"]
         }

--- a/test/transformers/oa3_transformer_test.rb
+++ b/test/transformers/oa3_transformer_test.rb
@@ -18,12 +18,12 @@ describe 'OpenAPI 3.0 Transformer' do
   it 'transforms path' do
     result = subject.transform_paths
     assert_equal({
-                   endpoint: '/pet',
+                   endpoint: '/api/v1/pet',
                    method: 'POST',
                    output_encoding: 'no-op',
                    input_headers: ['*'],
                    input_query_strings: ['*'],
-                   backend: [{ url_pattern: '/pet', encoding: 'no-op', host: ['https://example.org'] }],
+                   backend: [{ url_pattern: '/api/v1/pet', encoding: 'no-op', host: ['https://example.org'] }],
                    extra_config: {
                      'auth/validator': { 'alg' => 'RS256',
                                          'jwk_url' => 'https://keycloak.dev/auth/realms/dara/protocol/openid-connect/certs',


### PR DESCRIPTION
## Problem

Some OpenAPI schemas are specific to a single version of the API.

## Solution

Add base-path support to allow specifying API mount points such as /api, /api/v1, /api/v2, etc.